### PR TITLE
Use Bootstrap modal for delete confirmation

### DIFF
--- a/templates/riwayat.html
+++ b/templates/riwayat.html
@@ -102,6 +102,25 @@
 </div>
 {% endif %}
 
+<!-- Modal Konfirmasi Hapus -->
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteModalLabel">Konfirmasi Hapus</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        Apakah Anda yakin ingin menghapus riwayat dengan ID <span id="modal-riwayat-id"></span>?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Batal</button>
+        <button type="button" class="btn btn-danger" id="confirm-delete-btn">Ya</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Toast Container untuk notifikasi -->
 <div class="toast-container position-fixed top-0 end-0 p-3">
   <div id="deleteToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
@@ -122,59 +141,70 @@ document.addEventListener('DOMContentLoaded', function () {
     const riwayatContainer = document.getElementById('riwayat-container');
     const deleteToastEl = document.getElementById('deleteToast');
     const deleteToast = new bootstrap.Toast(deleteToastEl);
+    const deleteModalEl = document.getElementById('deleteModal');
+    const deleteModal = new bootstrap.Modal(deleteModalEl);
+    const modalRiwayatId = document.getElementById('modal-riwayat-id');
+    const confirmDeleteBtn = document.getElementById('confirm-delete-btn');
+    let selectedId = null;
 
     riwayatContainer.addEventListener('click', function (event) {
         if (event.target.classList.contains('delete-btn')) {
-            const button = event.target;
-            const riwayatId = button.dataset.id;
-            
-            if (confirm('Anda yakin ingin menghapus riwayat ini? Tindakan ini tidak dapat dibatalkan.')) {
-                fetch(`/riwayat/delete/${riwayatId}`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        // Jika menggunakan CSRF protection, tambahkan header di sini
-                    }
-                })
-                .then(response => response.json())
-                .then(data => {
-                    const toastBody = deleteToastEl.querySelector('.toast-body');
-                    if (data.status === 'success') {
-                        // Hapus elemen dari DOM
-                        const riwayatCard = document.getElementById(`riwayat-${riwayatId}`);
-                        riwayatCard.style.transition = 'opacity 0.5s ease';
-                        riwayatCard.style.opacity = '0';
-                        setTimeout(() => {
-                            riwayatCard.remove();
-                            // Cek jika kontainer kosong
-                            if (!riwayatContainer.querySelector('.col')) {
-                                riwayatContainer.innerHTML = '<div class="col-12"><div class="alert alert-info text-center"><p class="mb-0">Semua riwayat telah dihapus.</p></div></div>';
-                            }
-                        }, 500);
-
-                        // Tampilkan notifikasi sukses
-                        toastBody.textContent = data.message;
-                        deleteToastEl.classList.remove('text-bg-danger');
-                        deleteToastEl.classList.add('text-bg-success');
-                        deleteToast.show();
-                    } else {
-                        // Tampilkan notifikasi error
-                        toastBody.textContent = data.message || 'Terjadi kesalahan.';
-                        deleteToastEl.classList.remove('text-bg-success');
-                        deleteToastEl.classList.add('text-bg-danger');
-                        deleteToast.show();
-                    }
-                })
-                .catch(error => {
-                    console.error('Error:', error);
-                    const toastBody = deleteToastEl.querySelector('.toast-body');
-                    toastBody.textContent = 'Terjadi kesalahan jaringan.';
-                    deleteToastEl.classList.remove('text-bg-success');
-                    deleteToastEl.classList.add('text-bg-danger');
-                    deleteToast.show();
-                });
-            }
+            selectedId = event.target.dataset.id;
+            modalRiwayatId.textContent = selectedId;
+            deleteModal.show();
         }
+    });
+
+    confirmDeleteBtn.addEventListener('click', function () {
+        if (!selectedId) return;
+        fetch(`/riwayat/delete/${selectedId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                // Jika menggunakan CSRF protection, tambahkan header di sini
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            const toastBody = deleteToastEl.querySelector('.toast-body');
+            if (data.status === 'success') {
+                // Hapus elemen dari DOM
+                const riwayatCard = document.getElementById(`riwayat-${selectedId}`);
+                riwayatCard.style.transition = 'opacity 0.5s ease';
+                riwayatCard.style.opacity = '0';
+                setTimeout(() => {
+                    riwayatCard.remove();
+                    // Cek jika kontainer kosong
+                    if (!riwayatContainer.querySelector('.col')) {
+                        riwayatContainer.innerHTML = '<div class="col-12"><div class="alert alert-info text-center"><p class="mb-0">Semua riwayat telah dihapus.</p></div></div>';
+                    }
+                }, 500);
+
+                // Tampilkan notifikasi sukses
+                toastBody.textContent = data.message;
+                deleteToastEl.classList.remove('text-bg-danger');
+                deleteToastEl.classList.add('text-bg-success');
+                deleteToast.show();
+            } else {
+                // Tampilkan notifikasi error
+                toastBody.textContent = data.message || 'Terjadi kesalahan.';
+                deleteToastEl.classList.remove('text-bg-success');
+                deleteToastEl.classList.add('text-bg-danger');
+                deleteToast.show();
+            }
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            const toastBody = deleteToastEl.querySelector('.toast-body');
+            toastBody.textContent = 'Terjadi kesalahan jaringan.';
+            deleteToastEl.classList.remove('text-bg-success');
+            deleteToastEl.classList.add('text-bg-danger');
+            deleteToast.show();
+        })
+        .finally(() => {
+            deleteModal.hide();
+            selectedId = null;
+        });
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- add Bootstrap modal to confirm history deletion with dynamic ID display
- replace confirm() prompt with modal-driven workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bd825a7408332ab1d5c76b70adfa0