### PR TITLE
Load Bootstrap Icons globally

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,7 +7,10 @@
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    
+
+    <!-- Bootstrap Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     


### PR DESCRIPTION
## Summary
- Include Bootstrap Icons stylesheet in main layout so `<i class="bi ...">` elements display correctly.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bdd9e7d948332be4ad96586c64023