### PR TITLE
Add disease distribution chart on dashboard

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -113,18 +113,25 @@ def dashboard():
     # Statistik keseluruhan
     all_riwayat = Riwayat.query.filter_by(user_id=current_user.id).all()
     total_uploads = len(all_riwayat)
-    
+
     if all_riwayat:
         all_predictions = [r.prediction for r in all_riwayat]
-        most_common_disease = Counter(all_predictions).most_common(1)[0][0]
+        disease_counts = Counter(all_predictions)
+        disease_labels = list(disease_counts.keys())
+        disease_values = list(disease_counts.values())
+        most_common_disease = disease_counts.most_common(1)[0][0]
     else:
         most_common_disease = None
+        disease_labels = []
+        disease_values = []
 
-    return render_template('dashboard.html', 
+    return render_template('dashboard.html',
                            total_uploads=total_uploads,
                            last_disease=riwayat_list[0].prediction if riwayat_list else None,
                            most_common_disease=most_common_disease,
-                           riwayat_list=riwayat_list)
+                           riwayat_list=riwayat_list,
+                           disease_labels=disease_labels,
+                           disease_values=disease_values)
 
 # --- Rute Aplikasi Inti (Diproteksi) ---
 @main_bp.route('/klasifikasi')

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -38,6 +38,12 @@
         </div>
     </div>
 
+    <!-- Grafik Statistik Penyakit -->
+    <h3 class="mt-5 mb-3">Distribusi Penyakit</h3>
+    <div class="chart-container" style="position: relative; height:400px; width:100%;">
+        <canvas id="diseaseChart"></canvas>
+    </div>
+
     <!-- Riwayat Terbaru -->
     <h3 class="mb-3">Riwayat Analisis Terbaru</h3>
     <div class="list-group">
@@ -60,4 +66,34 @@
         <a href="{{ url_for('main.riwayat') }}" class="btn btn-secondary">Lihat Semua Riwayat</a>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts_extra %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+    const diseaseLabels = {{ disease_labels|tojson }};
+    const diseaseValues = {{ disease_values|tojson }};
+    const ctx = document.getElementById('diseaseChart').getContext('2d');
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: diseaseLabels,
+            datasets: [{
+                label: 'Jumlah Kasus',
+                data: diseaseValues,
+                backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                borderColor: 'rgba(75, 192, 192, 1)',
+                borderWidth: 1
+            }]
+        },
+        options: {
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    precision: 0
+                }
+            }
+        }
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Include disease distribution chart on the user dashboard using Chart.js
- Aggregate `Riwayat` data to build chart datasets in the dashboard route

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689be018b85c8332b8898efb8f09f98c